### PR TITLE
resolve NaN compile-time constant issue in message.c

### DIFF
--- a/third_party/upb/upb/message/internal/message.c
+++ b/third_party/upb/upb/message/internal/message.c
@@ -9,6 +9,7 @@
 
 #include <math.h>
 #include <string.h>
+#include <limits> // Added for std::numeric_limits
 
 #include "upb/base/internal/log2.h"
 #include "upb/mem/arena.h"
@@ -19,7 +20,7 @@
 
 const float kUpb_FltInfinity = INFINITY;
 const double kUpb_Infinity = INFINITY;
-const double kUpb_NaN = NAN;
+const double kUpb_NaN = std::numeric_limits<double>::quiet_NaN(); // Updated to use std::numeric_limits
 
 bool UPB_PRIVATE(_upb_Message_Realloc)(struct upb_Message* msg, size_t need,
                                        upb_Arena* a) {


### PR DESCRIPTION
Resolved the issue with `NAN` not being a compile-time constant in Windows 11 SDK 10.0.26100.0. Updated the definition of `kUpb_NaN` to use `std::numeric_limits<double>::quiet_NaN()` for better portability and compatibility.

Changes:
- Replaced the `NAN` macro with `std::numeric_limits<double>::quiet_NaN()` for the `kUpb_NaN` constant.

Important Note:
- NaN is no longer a compile-time constant in Windows 11 SDK 10.0.26100.0. Rolling back to Windows 11 SDK 10.0.22000.0 resolves this issue.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

